### PR TITLE
Fix for getting base package for project in multi-db project.

### DIFF
--- a/lib/buildr_plus/patches/group_project_patch.rb
+++ b/lib/buildr_plus/patches/group_project_patch.rb
@@ -24,7 +24,9 @@ class Buildr::Project
   end
 
   def group_as_package
-    base_group
+    base_group.end_with?(BuildrPlus::Db.artifact_suffix) ?
+      base_group.slice(/(.*)#{BuildrPlus::Db.artifact_suffix}/, 1) :
+      base_group
   end
 
   def group_as_path


### PR DESCRIPTION
In a multi-db project project.group != the base package. This fix lets you still get the base package from the project.