### PR TITLE
Move the GWT source server root.

### DIFF
--- a/lib/buildr_plus/roles/container.rb
+++ b/lib/buildr_plus/roles/container.rb
@@ -126,7 +126,7 @@ BuildrPlus::Roles.role(:container) do
           ipr.add_gwt_configuration(p,
                                     :gwt_module => gwt_module,
                                     :vm_parameters => '-Xmx3G',
-                                    :shell_parameters => "-port 8888 -codeServerPort 8889 -bindAddress 0.0.0.0 -war #{_(:artifacts, project.name)}/",
+                                    :shell_parameters => "-port 8888 -codeServerPort 8889 -bindAddress 0.0.0.0 -war #{_(:generated, 'gwt-export')}/",
                                     :launch_page => "http://127.0.0.1:8080/#{p.root_project.name}/#{path}")
         end
       end

--- a/lib/buildr_plus/roles/server.rb
+++ b/lib/buildr_plus/roles/server.rb
@@ -104,6 +104,7 @@ BuildrPlus::Roles.role(:server) do
   webroots = {}
   webroots[_(:source, :main, :webapp)] = '/'
   webroots[_(:source, :main, :webapp_local)] = '/' if BuildrPlus::FeatureManager.activated?(:gwt)
+  webroots[_('..', :generated, 'gwt-export')] = '/' if BuildrPlus::FeatureManager.activated?(:gwt)
 
   project.assets.paths.each do |path|
     next if path.to_s =~ /generated\/gwt\// && BuildrPlus::FeatureManager.activated?(:gwt)


### PR DESCRIPTION
Move the GWT source server root to a new directory to avoid Jetty getting upset about undeployable EJBs.

It looks like these are the only two changes we require.