### PR TITLE
Splitting Keycloak libs

### DIFF
--- a/lib/buildr_plus/features/libs.rb
+++ b/lib/buildr_plus/features/libs.rb
@@ -178,17 +178,22 @@ BuildrPlus::FeatureManager.feature(:libs) do |f|
       %w(org.jboss.logging:jboss-logging:jar:3.3.0.Final)
     end
 
+    def keycloak_core
+      %w(
+        org.keycloak:keycloak-core:jar:2.0.0.Final
+        org.keycloak:keycloak-common:jar:2.0.0.Final
+      ) + self.bouncycastle
+    end
+
     def keycloak
       %w(
         org.keycloak:keycloak-servlet-filter-adapter:jar:2.0.0.Final
-        org.keycloak:keycloak-core:jar:2.0.0.Final
-        org.keycloak:keycloak-common:jar:2.0.0.Final
         org.keycloak:keycloak-adapter-spi:jar:2.0.0.Final
         org.keycloak:keycloak-adapter-core:jar:2.0.0.Final
         org.realityforge.org.keycloak:keycloak-servlet-adapter-spi:jar:2.0.0.Final
-      ) + self.bouncycastle + self.keycloak_domgen_support + self.httpclient + self.jboss_logging
+      ) + self.keycloak_core + self.keycloak_domgen_support + self.httpclient + self.jboss_logging
     end
-
+    
     def replicant_client
       self.replicant + self.gwt_property_source + self.gwt_datatypes + self.gwt_webpoller
     end

--- a/lib/buildr_plus/features/libs.rb
+++ b/lib/buildr_plus/features/libs.rb
@@ -193,7 +193,7 @@ BuildrPlus::FeatureManager.feature(:libs) do |f|
         org.realityforge.org.keycloak:keycloak-servlet-adapter-spi:jar:2.0.0.Final
       ) + self.keycloak_core + self.keycloak_domgen_support + self.httpclient + self.jboss_logging
     end
-  
+
     def replicant_client
       self.replicant + self.gwt_property_source + self.gwt_datatypes + self.gwt_webpoller
     end

--- a/lib/buildr_plus/features/libs.rb
+++ b/lib/buildr_plus/features/libs.rb
@@ -193,7 +193,7 @@ BuildrPlus::FeatureManager.feature(:libs) do |f|
         org.realityforge.org.keycloak:keycloak-servlet-adapter-spi:jar:2.0.0.Final
       ) + self.keycloak_core + self.keycloak_domgen_support + self.httpclient + self.jboss_logging
     end
-    
+  
     def replicant_client
       self.replicant + self.gwt_property_source + self.gwt_datatypes + self.gwt_webpoller
     end


### PR DESCRIPTION
Split out the keycloak core jars for those who don't want the servlet adapter.