### PR TITLE
Fixed problem where feature activated? fails if feature is unknown.

### DIFF
--- a/lib/buildr_plus/feature_manager.rb
+++ b/lib/buildr_plus/feature_manager.rb
@@ -81,7 +81,7 @@ module BuildrPlus #nodoc
       end
 
       def activated?(key)
-        feature?(key) && feature_by_name(key).activated?
+        feature_by_name(key).activated?
       end
 
       def feature?(key)

--- a/lib/buildr_plus/feature_manager.rb
+++ b/lib/buildr_plus/feature_manager.rb
@@ -81,7 +81,7 @@ module BuildrPlus #nodoc
       end
 
       def activated?(key)
-        feature_by_name(key).activated?
+        feature?(key) && feature_by_name(key).activated?
       end
 
       def feature?(key)

--- a/lib/buildr_plus/roles/all_in_one.rb
+++ b/lib/buildr_plus/roles/all_in_one.rb
@@ -150,7 +150,7 @@ BuildrPlus::Roles.role(:all_in_one) do
   war_module_names = [project.iml.name]
   jpa_module_names = BuildrPlus::FeatureManager.activated?(:db) ? [project.iml.name] : []
   ejb_module_names =
-    BuildrPlus::FeatureManager.activated?(:db) || BuildrPlus::FeatureManager.activated?(:ee) ? [project.iml.name] : []
+    BuildrPlus::FeatureManager.activated?(:db) || BuildrPlus::FeatureManager.activated?(:ejb) ? [project.iml.name] : []
 
   ipr.add_exploded_war_artifact(project,
                                 :dependencies => dependencies,


### PR DESCRIPTION
I was having problems in Arena Map where the all-in-one.rb was doing this:
BuildrPlus::FeatureManager.activated?(:ee) 
and it was failing because :ee was unknown.

I updated the feature manager so that activated? returns false for unknown features.