### PR TITLE
Added variable to redirect deployment from development.

### DIFF
--- a/lib/buildr_plus/features/jenkins.rb
+++ b/lib/buildr_plus/features/jenkins.rb
@@ -254,7 +254,7 @@ CONTENT
 
     def deploy_stage(root_project)
       <<-DEPLOY_STEP
-          kinjen.deploy_stage( this, '#{root_project.name}' )
+          kinjen.deploy_stage( this, '#{root_project.name}', '#{deployment_environment}' )
       DEPLOY_STEP
     end
 


### PR DESCRIPTION
To support the job 'deploy-to-management' I've included an existing var in the deploy stage arguments.
BuildrPlus::Jenkins.deployment_environment = 'management'