### PR TITLE
Add support for push to docker hub during travis build 

### DIFF
--- a/lib/buildr_plus/features/ci.rb
+++ b/lib/buildr_plus/features/ci.rb
@@ -232,6 +232,9 @@ BuildrPlus::FeatureManager.feature(:ci) do |f|
           Redfish.domains.each do |domain|
             next unless domain.enable_rake_integration?
             next unless domain.dockerize?
+            if BuildrPlus::Docker.push_image?
+              pull_request_actions << "#{domain.task_prefix}:tag_and_push"
+            end
             taskname = "#{domain.task_prefix}:docker:rm"
             pull_request_actions << taskname
             package_actions << taskname

--- a/lib/buildr_plus/features/docker.rb
+++ b/lib/buildr_plus/features/docker.rb
@@ -12,6 +12,23 @@
 # limitations under the License.
 #
 BuildrPlus::FeatureManager.feature(:docker) do |f|
+  f.enhance(:Config) do
+    attr_writer :push_image
+
+    def push_image?
+      @push_image.nil? ? false : @push_image
+    end
+
+    def organisation=(organisation)
+      @organisation = organisation
+      self.push_image = true
+    end
+
+    def organisation
+      @organisation.nil? ? 'stocksoftware' : @organisation
+    end
+  end
+
   f.enhance(:ProjectExtension) do
     first_time do
       desc 'Delete all dangling images'

--- a/lib/buildr_plus/features/travis.rb
+++ b/lib/buildr_plus/features/travis.rb
@@ -89,6 +89,13 @@ CONTENT
 CONTENT
       end
 
+      if BuildrPlus::Docker.push_image?
+        content += <<CONTENT
+before_script:
+  docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
+CONTENT
+      end
+
       content += <<CONTENT
 script: buildr ci:pull_request
 git:


### PR DESCRIPTION


Add configuration of owning organisation for docker images (used from redfish during image push).