### PR TITLE
Added GWT feature config to set the code_server_port.

### DIFF
--- a/lib/buildr_plus/features/config.rb
+++ b/lib/buildr_plus/features/config.rb
@@ -230,7 +230,7 @@ BuildrPlus::FeatureManager.feature(:config) do |f|
       if BuildrPlus::FeatureManager.activated?(:gwt)
         prefix = "#{Reality::Naming.uppercase_constantize(root_project.name)}_CODE_SERVER_"
         environment.setting("#{prefix}HOST", 'localhost')
-        environment.setting("#{prefix}PORT", '8889')
+        environment.setting("#{prefix}PORT", BuildrPlus::Gwt.code_server_port)
       end
     end
 

--- a/lib/buildr_plus/features/gwt.rb
+++ b/lib/buildr_plus/features/gwt.rb
@@ -24,6 +24,12 @@ BuildrPlus::FeatureManager.feature(:gwt => [:sting, :jackson, :javascript]) do |
       @enable_gwt_js_exports.nil? ? false : !!@enable_gwt_js_exports
     end
 
+    attr_writer :code_server_port
+
+    def code_server_port
+      @code_server_port.nil? ? 8889 : @code_server_port
+    end
+
     def gwtc_java_args
       %w(-ea -Djava.awt.headless=true -Xms512M -Xmx1024M)
     end

--- a/lib/buildr_plus/roles/container.rb
+++ b/lib/buildr_plus/roles/container.rb
@@ -125,7 +125,7 @@ BuildrPlus::Roles.role(:container) do
                                   :start_javascript_debugger => false,
                                   :open_in_browser => false,
                                   :vm_parameters => '-Xmx3G',
-                                  :shell_parameters => "#{BuildrPlus::Gwt.enable_gwt_js_exports? ? '-generateJsInteropExports ' : ''}-codeServerPort 8889 -bindAddress 0.0.0.0 -deploy #{_(:generated, :gwt, 'deploy')} -extra #{_(:generated, :gwt, 'extra')} -war #{_(:generated, :gwt, 'war')} -style PRETTY -XmethodNameDisplayMode FULL -incremental -logLevel INFO -strict -nostartServer",
+                                  :shell_parameters => "#{BuildrPlus::Gwt.enable_gwt_js_exports? ? '-generateJsInteropExports ' : ''}-codeServerPort #{BuildrPlus::Gwt.code_server_port} -bindAddress 0.0.0.0 -deploy #{_(:generated, :gwt, 'deploy')} -extra #{_(:generated, :gwt, 'extra')} -war #{_(:generated, :gwt, 'war')} -style PRETTY -XmethodNameDisplayMode FULL -incremental -logLevel INFO -strict -nostartServer",
                                   :launch_page => "http://127.0.0.1:8080/#{p.root_project.name}/#{path}")
       end
     end


### PR DESCRIPTION
We often have to run multiple GWT apps locally in dev mode, so it will help a lot to have different code server ports per project.