### PR TITLE
Update to support GitHub packages.

### DIFF
--- a/lib/buildr_plus/features/ci.rb
+++ b/lib/buildr_plus/features/ci.rb
@@ -56,7 +56,7 @@ BuildrPlus::FeatureManager.feature(:ci) do |f|
       if project.ipr?
         project.task ':ci:common_setup' do
           repo_suffix = ENV['GIT_PROJECT'] && ENV['UPLOAD_REPO'].include?('github') ? '/' + ENV['GIT_PROJECT'] : ''
-          Buildr.repositories.release_to[:url] = ENV['UPLOAD_REPO']
+          Buildr.repositories.release_to[:url] = ENV['UPLOAD_REPO'] + repo_suffix
           Buildr.repositories.release_to[:username] = ENV['UPLOAD_USER']
           Buildr.repositories.release_to[:password] = ENV['UPLOAD_PASSWORD']
           ENV['TEST'] = 'all' unless ENV['TEST']

--- a/lib/buildr_plus/features/ci.rb
+++ b/lib/buildr_plus/features/ci.rb
@@ -55,6 +55,7 @@ BuildrPlus::FeatureManager.feature(:ci) do |f|
     after_define do |project|
       if project.ipr?
         project.task ':ci:common_setup' do
+          repo_suffix = ENV['GIT_PROJECT'] && ENV['UPLOAD_REPO'].include?('github') ? '/' + ENV['GIT_PROJECT'] : ''
           Buildr.repositories.release_to[:url] = ENV['UPLOAD_REPO']
           Buildr.repositories.release_to[:username] = ENV['UPLOAD_USER']
           Buildr.repositories.release_to[:password] = ENV['UPLOAD_PASSWORD']


### PR DESCRIPTION
GitHub packages requires the repository is part of the repository url.