### PR TITLE
Allow Keycloak Remote Client user to be set in buildfile.

### DIFF
--- a/lib/buildr_plus/features/config.rb
+++ b/lib/buildr_plus/features/config.rb
@@ -238,8 +238,8 @@ BuildrPlus::FeatureManager.feature(:config) do |f|
       prefix = remote_client.redfish_config_prefix
       environment.setting("#{prefix}_REALM", environment.keycloak.realm) unless environment.setting?("#{prefix}_REALM")
       environment.setting("#{prefix}_SERVER_URL", environment.keycloak.base_url) unless environment.setting?("#{prefix}_SERVER_URL")
-      environment.setting("#{prefix}_USERNAME", environment.keycloak.service_username) unless environment.setting?("#{prefix}_USERNAME")
-      environment.setting("#{prefix}_PASSWORD", environment.keycloak.service_password) unless environment.setting?("#{prefix}_PASSWORD")
+      environment.setting("#{prefix}_USERNAME", remote_client.username || environment.keycloak.service_username) unless environment.setting?("#{prefix}_USERNAME")
+      environment.setting("#{prefix}_PASSWORD", remote_client.password || environment.keycloak.service_password) unless environment.setting?("#{prefix}_PASSWORD")
       environment.setting("#{prefix}_CLIENT_NAME", remote_client.name) unless environment.setting?("#{prefix}_CLIENT_NAME")
       environment.setting("#{prefix}_SECRET", remote_client.secret_value) unless environment.setting?("#{prefix}_SECRET")
     end

--- a/lib/buildr_plus/features/keycloak.rb
+++ b/lib/buildr_plus/features/keycloak.rb
@@ -21,6 +21,8 @@ module BuildrPlus::Keycloak
 
     attr_reader :client_type
     attr_accessor :application
+    attr_accessor :username
+    attr_accessor :password
 
     def default?
       self.client_type.to_s == self.application.to_s


### PR DESCRIPTION
Lets me do this in the buildfile:
BuildrPlus::Keycloak.remote_client(:Procurement, {:username=>'arena-register-application', :password=>'asdfasdf'})
