### PR TITLE
Update gwt-keycloak library version

### DIFF
--- a/lib/buildr_plus/features/libs.rb
+++ b/lib/buildr_plus/features/libs.rb
@@ -204,7 +204,7 @@ BuildrPlus::FeatureManager.feature(:libs) do |f|
     end
 
     def keycloak_gwt
-      %w(org.realityforge.gwt.keycloak:gwt-keycloak:jar:0.12) + self.akasha
+      %w(org.realityforge.gwt.keycloak:gwt-keycloak:jar:0.13) + self.akasha
     end
 
     def keycloak_domgen_support


### PR DESCRIPTION
Blocked by: https://github.com/realityforge/gwt-keycloak/pull/7